### PR TITLE
Add tip how to use the GitHub version in replace of the bundled version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ This is far from a complete list, but a few planned features are listed here to 
 Tips and Tricks
 ===========
 * In order to workaround the [Delphi XE3 Bug](https://github.com/VSoftTechnologies/DUnitX/issues/117), you need to add the unit DUnitX.Init to your test projects.
+* To use this GitHub version of DUnitX in place of the bundled version included iwth RAD Studio, it’s pretty simple by following these steps (as the bundled version is quite a few commits behind this repo):
+  - Remove the Embarcadero Unit test package (DUnitXIDEExpert280.bpl) from the installed packages list.
+  - In the cloned repo, open DUnitX_IDE_Expert_D11Alexandria.dproj, compile and install the package.
+  - In your unit test projects, adjust your search paths to point to the repo\Source folder.
+
 
 Support
 =======


### PR DESCRIPTION
Tip taken from a Nov 30th, 2022 Discourse comment from Vicent